### PR TITLE
Update to current Meteor package server URL

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,3 +1,3 @@
 App = {};
 
-App.packageServerUrl = 'packages.meteor.com';
+App.packageServerUrl = 'https://packages.meteor.com';


### PR DESCRIPTION
Hi, this commit makes cosmosphere work again with the current Meteor package server.

I just added https:// basically, I think that should do the trick, but I don't have any deeper understanding about any of this, what the servers are and how this works, aside from that it does seem to work again with this little update.

Use it with this grain of salt.